### PR TITLE
fix issue of violations with duplicated way ids

### DIFF
--- a/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/osmapi/fetch/OsmDataConverter.java
+++ b/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/osmapi/fetch/OsmDataConverter.java
@@ -25,7 +25,7 @@ class OsmDataConverter {
                     duplicatingWayCandidate.get()
             ));
         }
-        log.warn("Incomplete data for violation relation id {}", osmData.getRelation().getId());
+        log.warn("Incomplete data for violation: {}", osmData);
         return Optional.empty();
     }
 

--- a/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/osmose/DuplicatedViolationFilter.java
+++ b/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/osmose/DuplicatedViolationFilter.java
@@ -1,0 +1,50 @@
+package osm.bots.rings.inner.duplicates.osmose;
+
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+class DuplicatedViolationFilter {
+
+    List<DuplicatedInnerPolygonViolation> deduplicate(List<DuplicatedInnerPolygonViolation> violations) {
+        DeduplicateWorker deduplicateWorker = new DeduplicateWorker(violations);
+        List<DuplicatedInnerPolygonViolation> filteredViolations = deduplicateWorker.getFilteredViolations();
+        log.info("{} violations were filtered out due to common way ID in read violations", violations.size() - filteredViolations.size());
+        return filteredViolations;
+    }
+
+    @Value
+    private static class DeduplicateWorker {
+
+        List<DuplicatedInnerPolygonViolation> filteredViolations;
+
+        private DeduplicateWorker(List<DuplicatedInnerPolygonViolation> violations) {
+            this.filteredViolations = new ArrayList<>(violations);
+            deduplicate();
+        }
+
+       private void deduplicate() {
+            Map<Long, List<DuplicatedInnerPolygonViolation>> violationsGroupedByWayId = new HashMap<>();
+            filteredViolations.forEach(violation -> groupViolationsByWayId(violation, violationsGroupedByWayId));
+            removeDuplicatedViolations(violationsGroupedByWayId);
+        }
+
+        private void removeDuplicatedViolations(Map<Long, List<DuplicatedInnerPolygonViolation>> violationsGroupedByWayId) {
+            violationsGroupedByWayId
+                    .values()
+                    .stream()
+                    .filter(duplicatedInnerPolygonViolations -> duplicatedInnerPolygonViolations.size() > 1)
+                    .forEach(filteredViolations::removeAll);
+        }
+
+        private void groupViolationsByWayId(DuplicatedInnerPolygonViolation violation, Map<Long, List<DuplicatedInnerPolygonViolation>> violationsGroupedByWayId) {
+            violation.getPairOfViolatingWaysIds()
+                    .forEach(violationId -> violationsGroupedByWayId.computeIfAbsent(violationId, key -> new ArrayList<>()).add(violation));
+        }
+    }
+}

--- a/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/osmose/OsmoseConfiguration.java
+++ b/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/osmose/OsmoseConfiguration.java
@@ -7,8 +7,11 @@ import org.springframework.context.annotation.Configuration;
 class OsmoseConfiguration {
 
     @Bean
-    OsmoseViolationsFetcher getOsmoseViolationsFetcher() {
-        return new OsmoseViolationsFetcher(getViolationJsonReader(), getOsmoseViolationsValidator());
+    OsmoseViolationsFetcher getOsmoseViolationsFetcher(
+            OsmoseViolationsJsonReader osmoseViolationsJsonReader,
+            OsmoseViolationsValidator osmoseViolationsValidator,
+            DuplicatedViolationFilter duplicatedViolationFilter) {
+        return new OsmoseViolationsFetcher(osmoseViolationsJsonReader, osmoseViolationsValidator, duplicatedViolationFilter);
     }
 
     @Bean
@@ -19,5 +22,10 @@ class OsmoseConfiguration {
     @Bean
     OsmoseViolationsValidator getOsmoseViolationsValidator() {
         return new OsmoseViolationsValidator();
+    }
+
+    @Bean
+    DuplicatedViolationFilter getDuplicatedViolationFilter() {
+        return new DuplicatedViolationFilter();
     }
 }

--- a/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/osmose/OsmoseViolationsFetcher.java
+++ b/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/osmose/OsmoseViolationsFetcher.java
@@ -10,9 +10,11 @@ public class OsmoseViolationsFetcher {
 
     private final OsmoseViolationsJsonReader reader;
     private final OsmoseViolationsValidator validator;
+    private final DuplicatedViolationFilter duplicatedViolationsFilter;
 
     public List<DuplicatedInnerPolygonViolation> fetchViolations(Path path) {
         List<DuplicatedInnerPolygonViolation> allViolations = reader.read(path);
-        return validator.getValidViolations(allViolations);
+        List<DuplicatedInnerPolygonViolation> deduplicatedViolations = duplicatedViolationsFilter.deduplicate(allViolations);
+        return validator.getValidViolations(deduplicatedViolations);
     }
 }

--- a/bot-double-inner-ring/src/main/resources/logback-spring.xml
+++ b/bot-double-inner-ring/src/main/resources/logback-spring.xml
@@ -35,8 +35,4 @@
         <appender-ref ref="Console"/>
     </root>
 
-    <logger name="osm.bots.rings.inner.duplicates" level="debug" additivity="false">
-        <appender-ref ref="RollingFile"/>
-    </logger>
-
 </configuration>

--- a/bot-double-inner-ring/src/test/java/osm/bots/rings/inner/duplicates/osmose/DuplicatedViolationFilterTest.java
+++ b/bot-double-inner-ring/src/test/java/osm/bots/rings/inner/duplicates/osmose/DuplicatedViolationFilterTest.java
@@ -1,0 +1,94 @@
+package osm.bots.rings.inner.duplicates.osmose;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Singular;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DuplicatedViolationFilterTest {
+
+    private DuplicatedViolationFilter duplicatedViolationsFilter;
+
+    public static Stream<Arguments> getTestCases() {
+
+        return Stream.of(
+                testCase()
+                        .description("Two different violations should not be filtered out")
+                        .violation(duplicatedInnerPolygonViolation()
+                                .wayId(1L)
+                                .wayId(2L))
+                        .violation(duplicatedInnerPolygonViolation()
+                                .wayId(3L)
+                                .wayId(4L))
+                        .expectedViolation(duplicatedInnerPolygonViolation()
+                                .wayId(1L)
+                                .wayId(2L))
+                        .expectedViolation(duplicatedInnerPolygonViolation()
+                                .wayId(3L)
+                                .wayId(4L)),
+                testCase()
+                        .description("Two violations with the same way IDs should be filtered out")
+                        .violation(duplicatedInnerPolygonViolation()
+                                .wayId(1L)
+                                .wayId(2L))
+                        .violation(duplicatedInnerPolygonViolation()
+                                .wayId(1L)
+                                .wayId(2L)),
+                testCase()
+                        .description("Two violations with one the same way ID should be filtered out")
+                        .violation(duplicatedInnerPolygonViolation()
+                                .wayId(1L)
+                                .wayId(2L))
+                        .violation(duplicatedInnerPolygonViolation()
+                                .wayId(3L)
+                                .wayId(2L)))
+                .map(ArgumentsBuilder::build);
+    }
+
+    @Builder(builderMethodName = "testCase")
+    private static Arguments buildTestCase(
+            @NonNull String description,
+            @Singular List<DuplicatedInnerPolygonViolationBuilder> violations,
+            @Singular List<DuplicatedInnerPolygonViolationBuilder> expectedViolations) {
+        return Arguments.of(description, buildViolations(violations), buildViolations(expectedViolations));
+    }
+
+    private static List<DuplicatedInnerPolygonViolation> buildViolations(List<DuplicatedInnerPolygonViolationBuilder> violations) {
+        return violations
+                .stream()
+                .map(DuplicatedInnerPolygonViolationBuilder::build)
+                .collect(Collectors.toList());
+    }
+
+    @Builder(builderMethodName = "duplicatedInnerPolygonViolation", builderClassName = "DuplicatedInnerPolygonViolationBuilder")
+    private static DuplicatedInnerPolygonViolation buildDuplicatedInnerPolygonViolation(
+            int osmoseRuleId,
+            @Singular List<Long> relationIds,
+            @Singular List<Long> wayIds) {
+        return new DuplicatedInnerPolygonViolation(osmoseRuleId, new ViolatingOsmIds(relationIds, wayIds));
+    }
+
+    @BeforeEach
+    void setUp() {
+        duplicatedViolationsFilter = new DuplicatedViolationFilter();
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("getTestCases")
+    void shouldDeduplicateViolations(String description, List<DuplicatedInnerPolygonViolation> violations, List<DuplicatedInnerPolygonViolation> expected) {
+        //  when
+        List<DuplicatedInnerPolygonViolation> actual = duplicatedViolationsFilter.deduplicate(violations);
+
+        //  then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+}


### PR DESCRIPTION
In this PR, there is a fix for violations which contains the same way ID. Such violations are filtered out not fixed by the InnerRing BOT