### PR TITLE
fix-issue-of-coastline

### DIFF
--- a/bot-double-inner-ring/README.md
+++ b/bot-double-inner-ring/README.md
@@ -26,6 +26,7 @@ Following checks are executed:
 * both ways are closed and have the same nodes (direction of way digitization and starting node can be different),
 * duplicating way should have tags,
 * duplicating way is not member of any relation,
+* duplicating way is not a coast-line with reversed geometry,
 * inner ring way should have no tags,
 * inner ring way is member of only 1 relation (the one from Osmose violation),
 * optional: relation and duplicating way should have required "source" tag (e.g. "source=CanVec 8.0 - NRCan).
@@ -108,6 +109,10 @@ Following run parameters are optional, but it is not recommended, to change thei
 * The `verifier.duplicating-way-is-not-member-of-any-relation.active` informs BOT, if it should verify that duplicating way is not a member of any relation 
   (default value is true).
 >   --run.parameters.verifier.duplicating-way-is-not-member-of-any-relation.active=true
+
+* The `verifier.duplicating-way-is-not-reverted-coastline.active` informs BOT, if it should verify that duplicating way is not a coast-line with geometry 
+  other than inner ring way (default value is true).
+>   --run.parameters.verifier.duplicating-way-is-not-reverted-coastline.active=true
 
 * The `verifier.inner-ring-way-has-no-tags.active` informs BOT, if it should verify that inner ring way has not tags (default value is true).
 >   --run.parameters.verifier.inner-ring-way-has-no-tags.active=true

--- a/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/verifiers/DuplicatingWayIsNotRevertedCoastLineVerifier.java
+++ b/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/verifiers/DuplicatingWayIsNotRevertedCoastLineVerifier.java
@@ -1,0 +1,41 @@
+package osm.bots.rings.inner.duplicates.verifiers;
+
+import de.westnordost.osmapi.map.data.Element;
+import osm.bots.rings.inner.duplicates.osmapi.model.ViolatingOsmData;
+import osm.bots.rings.inner.duplicates.osmapi.model.WayWithParentRelations;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+final class DuplicatingWayIsNotRevertedCoastLineVerifier extends Verifier {
+
+    private static final String COAST_LINE_TAG_KEY = "natural";
+    private static final String COAST_LINE_TAG_VALUE = "coastline";
+
+    @Override
+    boolean isMatchingVerifierCriteria(ViolatingOsmData violatingOsmData) {
+        WayWithParentRelations duplicatingWay = violatingOsmData.getDuplicatingWay();
+        boolean hasCoastLineTag = getNaturalTagValue(duplicatingWay.getWay())
+                .filter(isCoastline())
+                .isPresent();
+        if (hasCoastLineTag) {
+            List<Long> duplicatingWayNodeIds = duplicatingWay.getNodesOfWay();
+            List<Long> innerRingNodes = violatingOsmData.getInnerRingWay().getNodesOfWay();
+            return innerRingNodes.equals(duplicatingWayNodeIds);
+        }
+        return true;
+    }
+
+    private Optional<String> getNaturalTagValue(Element element) {
+        String naturalTagValue = element
+                .getTags()
+                .get(COAST_LINE_TAG_KEY);
+        return Optional.ofNullable(naturalTagValue);
+    }
+
+    private Predicate<String> isCoastline() {
+        return tagValue -> tagValue.equalsIgnoreCase(COAST_LINE_TAG_VALUE);
+    }
+}
+

--- a/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/verifiers/VerifierConfiguration.java
+++ b/bot-double-inner-ring/src/main/java/osm/bots/rings/inner/duplicates/verifiers/VerifierConfiguration.java
@@ -34,6 +34,12 @@ class VerifierConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "run.parameters.verifier.duplicating-way-is-not-reverted-coastline", name = "active")
+    DuplicatingWayIsNotRevertedCoastLineVerifier duplicatingWayIsNotRevertedCoastLine() {
+        return new DuplicatingWayIsNotRevertedCoastLineVerifier();
+    }
+
+    @Bean
     @ConditionalOnProperty(prefix = "run.parameters.verifier.inner-ring-way-has-no-tags", name = "active")
     InnerRingWayHasNoTagsVerifier innerRingWayHasNoTagsVerifier() {
         return new InnerRingWayHasNoTagsVerifier();

--- a/bot-double-inner-ring/src/test/java/osm/bots/rings/inner/duplicates/verifiers/DuplicatingWayIsNotRevertedCoastLineVerifierTest.java
+++ b/bot-double-inner-ring/src/test/java/osm/bots/rings/inner/duplicates/verifiers/DuplicatingWayIsNotRevertedCoastLineVerifierTest.java
@@ -1,0 +1,68 @@
+package osm.bots.rings.inner.duplicates.verifiers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import osm.bots.rings.inner.duplicates.osmapi.model.ViolatingOsmData;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class DuplicatingWayIsNotRevertedCoastLineVerifierTest {
+
+    private static final List<Long> CLOSED_RING = List.of(1L, 2L, 3L, 4L, 1L);
+    private static final List<Long> CLOSED_RING_REVERTED = List.of(1L, 4L, 3L, 2L, 1L);
+
+    public static Stream<Arguments> getTestCases() {
+        return Stream.of(
+                TestCaseGenerator.testCase()
+                        .name("Duplicated way without any tags is not coastline")
+                        .innerRingWayNodes(CLOSED_RING)
+                        .duplicatingWayNodes(CLOSED_RING)
+                        .verifierResult(true),
+                TestCaseGenerator.testCase()
+                        .name("Duplicated way with random tag is not coastline")
+                        .innerRingWayNodes(CLOSED_RING)
+                        .duplicatingWayNodes(CLOSED_RING)
+                        .duplicatingWayTags(Map.of("random", "random"))
+                        .verifierResult(true),
+                TestCaseGenerator.testCase()
+                        .name("Duplicated way with tag natural=scrub is not coastline")
+                        .innerRingWayNodes(CLOSED_RING)
+                        .duplicatingWayNodes(CLOSED_RING)
+                        .duplicatingWayTags(Map.of("natural", "scrub"))
+                        .verifierResult(true),
+                TestCaseGenerator.testCase()
+                        .name("Duplicated way with tag natural=coastline and same geometry as inner ring way is coastline")
+                        .innerRingWayNodes(CLOSED_RING)
+                        .duplicatingWayNodes(CLOSED_RING)
+                        .duplicatingWayTags(Map.of("natural", "coastline"))
+                        .verifierResult(true),
+                TestCaseGenerator.testCase()
+                        .name("Duplicated way with tag natural=coastline but with other geometry than inner ring way is not coastline")
+                        .innerRingWayNodes(CLOSED_RING_REVERTED)
+                        .duplicatingWayNodes(CLOSED_RING)
+                        .duplicatingWayTags(Map.of("natural", "coastline"))
+                        .verifierResult(false))
+                .map(TestCaseGenerator.TestCaseBuilder::build);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("getTestCases")
+    void shouldVerifyCoastLine(
+            String description,
+            ViolatingOsmData violatingOsmData,
+            boolean verifierResult) {
+        // Given
+        DuplicatingWayIsNotRevertedCoastLineVerifier duplicatingWayIsNotRevertedCoastLineVerifier = new DuplicatingWayIsNotRevertedCoastLineVerifier();
+
+        // When
+        boolean verificationResults = duplicatingWayIsNotRevertedCoastLineVerifier.isMatchingVerifierCriteria(violatingOsmData);
+
+        // Then
+        assertThat(verificationResults).isEqualTo(verifierResult);
+    }
+}


### PR DESCRIPTION
it looks that sometimes duplicated inner rings can be also represented by the ways with coast line tag where direction of nodes is important. Decided to not fix duplicated inner rings with coast line tag where nodes direction differ between inner ring way and duplicating way.